### PR TITLE
Fixed path to taxonomy FAQ

### DIFF
--- a/submit/samples.rst
+++ b/submit/samples.rst
@@ -47,7 +47,7 @@ Please also make sure you are familiar with the `ENA's taxonomy services <faq/ta
 and use the correct taxonomy to describe your samples.
 
 In particular, consider the `environmental
-taxonomy <faq/taxonomy.html#environmental-taxonomic-classifications>`_ options available to you when
+taxonomy <../faq/taxonomy.html#environmental-taxonomic-classifications>`_ options available to you when
 working with environmental samples.
 
 Accessions


### PR DESCRIPTION
https://ena-docs.readthedocs.io/en/latest/submit/samples.html has a broken link to:

https://ena-docs.readthedocs.io/en/latest/submit/faq/taxonomy.html#environmental-taxonomic-classifications

This change should make the link point here:

https://ena-docs.readthedocs.io/en/latest/faq/taxonomy.html#environmental-taxonomic-classifications