### PR TITLE
fix config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: requirements.txt
+ python:
+   install:
+   - requirements: requirements.txt

--- a/conf.py
+++ b/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinx_tabs.tabs', 'myst_parser']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -84,6 +84,10 @@ todo_include_todos = False
 #
 # html_theme = 'alabaster'
 html_theme = "sphinx_rtd_theme"
+# Jasmine addition: please note that the theme is now specified in the requirements file as sphinx_rtd_theme
+# Jasmine addition: please note that any docs breaking could be due to a required package changing
+# Jasmine addition: it is reccommended to pin requirments - see https://docs.readthedocs.io/en/stable/guides/rep>
+
 
 # marc addition: from http://stackoverflow.com/questions/18969093/how-to-include-the-toctree-in-the-sidebar-of-each-page
 # remove if causing issues. forces globaltoc.html
@@ -162,10 +166,11 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
+# Jasmine addition: use recommonmarkparser to parse .md files, remove if causing issues
+#from recommonmark.parser import CommonMarkParser
+#
+#source_parsers = {
+#    '.md': CommonMarkParser,
+#}
 
 source_suffix = ['.rst', '.md']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-docutils<0.17
+sphinx<7
+sphinx_rtd_theme
+docutils
+sphinx-tabs
+myst_parser


### PR DESCRIPTION
- replaces '.readthedocs..yaml' with the correct '.readthedocs.yaml'
- conf.py remove commonmarlparser, tody conf.py 
- -requirments.txt - unpin docutils and pin sphinx to <7