### PR TITLE
fix lost changes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
- python:
-   install:
+python:
+  install:
    - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,10 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: conf.py
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: requirements.txt
+ python:
+   install:
+   - requirements: requirements.txt

--- a/conf.py
+++ b/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinx_tabs.tabs', 'myst_parser']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -83,7 +83,12 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 # html_theme = 'alabaster'
+# Jasmine addition: please note that the theme is now specified in the requirements file as sphinx_rtd_theme
+# Jasmine addition: please note that any docs breaking could be due to a required package changing
+# Jasmine addition: it is reccommended to pin requirments - see https://docs.readthedocs.io/en/stable/guides/rep>
 html_theme = "sphinx_rtd_theme"
+
+
 
 # marc addition: from http://stackoverflow.com/questions/18969093/how-to-include-the-toctree-in-the-sidebar-of-each-page
 # remove if causing issues. forces globaltoc.html
@@ -162,10 +167,11 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
+# Jasmine addition: test use recommonmarkparser to parse .md files, remove if causing issues
+#from recommonmark.parser import CommonMarkParser
+#
+#source_parsers = {
+#    '.md': CommonMarkParser,
+#}
 
 source_suffix = ['.rst', '.md']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-docutils<0.17
+sphinx<7
+sphinx_rtd_theme
+docutils
+sphinx-tabs
+myst_parser


### PR DESCRIPTION
Open pull request to fix config and recover lost documentation changes

fix config:
- '.readthedocs..yaml' remaned to .readthedocs.yaml and content corrected
- conf.py conf.py tidied up, remove recommonmarkparser
- requirements.txt - add requirements, unpin docutils from <17 and pin sphinx to <7