### PR TITLE
pin dependencies, fix .md rendering

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -178,4 +178,3 @@ source_suffix = {
     '.md': 'markdown',
 }
 
-source_suffix = ['.rst', '.md']

--- a/conf.py
+++ b/conf.py
@@ -167,9 +167,15 @@ texinfo_documents = [
 
 # Jasmine addition: test use recommonmarkparser to parse .md files, remove if causing issues
 #from recommonmark.parser import CommonMarkParser
-#
+#  
 #source_parsers = {
 #    '.md': CommonMarkParser,
 #}
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'markdown',
+    '.md': 'markdown',
+}
 
 source_suffix = ['.rst', '.md']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==6.2.1
 sphinx_rtd_theme==1.3.0
-docutils>18
+docutils>0.18
 sphinx-tabs==3.4.1
 myst_parser==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==6.2.1
 sphinx_rtd_theme==1.3.0
-docutils==0.20.*
+docutils<0.20
 sphinx-tabs==3.4.1
 myst_parser==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<7
+sphinx>2.1
 sphinx_rtd_theme
 docutils
 sphinx-tabs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sphinx>2.1
-sphinx_rtd_theme
-docutils
-sphinx-tabs
-myst_parser
+sphinx==6.2.1
+sphinx_rtd_theme==1.3.0
+docutils==0.20.1
+sphinx-tabs==3.4.1
+myst_parser==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==6.2.1
 sphinx_rtd_theme==1.3.0
-docutils>0.18
+docutils==0.20.*
 sphinx-tabs==3.4.1
 myst_parser==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx==6.2.1
 sphinx_rtd_theme==1.3.0
-docutils==0.20.1
+docutils>18
 sphinx-tabs==3.4.1
 myst_parser==2.0.0

--- a/submit/analyses/bionano-maps.md
+++ b/submit/analyses/bionano-maps.md
@@ -9,7 +9,7 @@ To submit an analysis programmatically, two XML files must be generated to descr
 
 These are then submitted to ENA through the secure HTTPS protocol using POST multipart/form-data 
 according to RFC1867. Please see the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 ## Step 1: Create Analysis XML
 
@@ -83,7 +83,7 @@ and `<RUN_REF>` elements. Again, either an accession or alias can be used in the
 
 #### Upload Data Files
 
-Please [upload](../fileprep/upload.html) all data files required for submission.
+Please [upload](../fileprep/upload) all data files required for submission.
 
 Once the analysis has been submitted, all the data files described in the analysis XML will be moved 
 from the Webin upload area into the archive.
@@ -159,12 +159,12 @@ XML in a separate file to tell ENA what actions you would like to take for your 
 ```
 
 The submission XML declares one or more Webin submission service actions. See the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html>) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 In this case the action is `<ADD/>` which is used to submit new objects.
 
 The XMLs can then be submitted programmatically, using CURL on command line or
-using the [Webin Portal](../general-guide/submissions-portal.html).
+using the [Webin Portal](../general-guide/submissions-portal).
 
 ## Step 3: Submit the XMLs
 
@@ -196,8 +196,8 @@ After running the command above a receipt XML is returned. It will look like the
 
 ### Submit the XMLs Using Webin Portal
 
-XMLs can also be submitted interactively using the [Webin portal](../general-guide/submissions-portal.html).
-Please refer to the [Webin Portal](../general-guide/submissions-portal.html) document for an example how
+XMLs can also be submitted interactively using the [Webin portal](../general-guide/submissions-portal).
+Please refer to the [Webin Portal](../general-guide/submissions-portal) document for an example how
 to submit a study using XML. Other types of XMLs can be submitted using the same approach.
 
 ### The Receipt XML
@@ -230,5 +230,5 @@ but this time using the production service. Simply change the part in the URL fr
 curl -u username:password -F "SUBMISSION=@submission.xml" -F "ANALYSIS=@analysis.xml" "https://www.ebi.ac.uk/ena/submit/drop-box/submit/"
 ```
 
-Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal.html) change the URL from
+Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal) change the URL from
 `wwwdev.ebi.ac.uk` to `www.ebi.ac.uk`.

--- a/submit/analyses/pacbio-methylation.md
+++ b/submit/analyses/pacbio-methylation.md
@@ -9,7 +9,7 @@ To submit an analysis programmatically, two XML files must be generated to descr
 
 These are then submitted to ENA through the secure HTTPS protocol using POST multipart/form-data 
 according to RFC1867. Please see the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 ## Step 1: Create Analysis XML
 
@@ -88,7 +88,7 @@ and `<RUN_REF>` elements. Again, either an accession or alias can be used in the
 
 #### Upload Data Files
 
-Please [upload](../fileprep/upload.html) all data files required for submission.
+Please [upload](../fileprep/upload) all data files required for submission.
 
 Once the analysis has been submitted, all the data files described in the analysis XML will be moved 
 from the Webin upload area into the archive.
@@ -163,12 +163,12 @@ XML in a separate file to tell ENA what actions you would like to take for your 
 ```
 
 The submission XML declares one or more Webin submission service actions. See the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html>) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 In this case the action is `<ADD/>` which is used to submit new objects.
 
 The XMLs can then be submitted programmatically, using CURL on command line or
-using the [Webin Portal](../general-guide/submissions-portal.html).
+using the [Webin Portal](../general-guide/submissions-portal).
 
 ## Step 3: Submit the XMLs
 
@@ -200,8 +200,8 @@ After running the command above a receipt XML is returned. It will look like the
 
 ### Submit the XMLs Using Webin Portal
 
-XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal.html).
-Please refer to the [Webin Portal](../general-guide/submissions-portal.html) document for an example how
+XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal).
+Please refer to the [Webin Portal](../general-guide/submissions-portal) document for an example how
 to submit a study using XML. Other types of XMLs can be submitted using the same approach.
 
 ### The Receipt XML
@@ -234,5 +234,5 @@ but this time using the production service. Simply change the part in the URL fr
 curl -u username:password -F "SUBMISSION=@submission.xml" -F "ANALYSIS=@analysis.xml" "https://www.ebi.ac.uk/ena/submit/drop-box/submit/"
 ```
 
-Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal.html) change the URL from
+Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal) change the URL from
 `wwwdev.ebi.ac.uk` to `www.ebi.ac.uk`.

--- a/submit/analyses/read-alignments.md
+++ b/submit/analyses/read-alignments.md
@@ -9,7 +9,7 @@ To submit an analysis programmatically, two XML files must be generated to descr
 
 These are then submitted to ENA through the secure HTTPS protocol using POST multipart/form-data 
 according to RFC1867. Please see the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 ## Step 1: Create Analysis XML
 
@@ -89,7 +89,7 @@ you must reference any reference genomes or sequences used for the alignment.
 ```
 
 Please note additionally that the reads used in the alignment should also already have been submitted following
-instructions in [Submit Read Data](../reads.html).
+instructions in [Submit Read Data](../reads).
 
 Read alignment analyses must be associated with a study and can be associated with
 one or more samples.
@@ -126,7 +126,7 @@ and `<RUN_REF>` elements. Again, either an accession or alias can be used in the
 
 #### Upload Data Files
 
-Please [upload](../fileprep/upload.html) all data files required for submission.
+Please [upload](../fileprep/upload) all data files required for submission.
 
 Once the analysis has been submitted, all the data files described in the analysis XML will be moved 
 from the Webin upload area into the archive.
@@ -192,12 +192,12 @@ XML in a separate file to tell ENA what actions you would like to take for your 
 ```
 
 The submission XML declares one or more Webin submission service actions. See the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html>) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 In this case the action is `<ADD/>` which is used to submit new objects.
 
 The XMLs can then be submitted programmatically, using CURL on command line or
-using the [Webin Portal](../general-guide/submissions-portal.html).
+using the [Webin Portal](../general-guide/submissions-portal).
 
 ## Step 3: Submit the XMLs
 
@@ -229,8 +229,8 @@ After running the command above a receipt XML is returned. It will look like the
 
 ### Submit the XMLs Using Webin Portal
 
-XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal.html).
-Please refer to the [Webin Portal](../general-guide/submissions-portal.html) document for an example how
+XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal).
+Please refer to the [Webin Portal](../general-guide/submissions-portal) document for an example how
 to submit a study using XML. Other types of XMLs can be submitted using the same approach.
 
 ### The Receipt XML
@@ -263,5 +263,5 @@ but this time using the production service. Simply change the part in the URL fr
 curl -u username:password -F "SUBMISSION=@submission.xml" -F "ANALYSIS=@analysis.xml" "https://www.ebi.ac.uk/ena/submit/drop-box/submit/"
 ```
 
-Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal.html) change the URL from
+Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal) change the URL from
 `wwwdev.ebi.ac.uk` to `www.ebi.ac.uk`.

--- a/submit/analyses/sequence-annotation.md
+++ b/submit/analyses/sequence-annotation.md
@@ -9,7 +9,7 @@ To submit an analysis programmatically, two XML files must be generated to descr
 
 These are then submitted to ENA through the secure HTTPS protocol using POST multipart/form-data 
 according to RFC1867. Please see the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 ## Step 1: Create Analysis XML
 
@@ -82,7 +82,7 @@ and `<RUN_REF>` elements. Again, either an accession or alias can be used in the
 
 #### Upload Data Files
 
-Please [upload](../fileprep/upload.html) all data files required for submission.
+Please [upload](../fileprep/upload) all data files required for submission.
 
 Once the analysis has been submitted, all the data files described in the analysis XML will be moved 
 from the Webin upload area into the archive.
@@ -148,12 +148,12 @@ XML in a separate file to tell ENA what actions you would like to take for your 
 ```
 
 The submission XML declares one or more Webin submission service actions. See the general guide on 
-[Programmatic Submission](../general-guide/programmatic.html) for more information.
+[Programmatic Submission](../general-guide/programmatic) for more information.
 
 In this case the action is `<ADD/>` which is used to submit new objects.
 
 The XMLs can then be submitted programmatically, using CURL on command line or
-using the [Webin Portal](../general-guide/submissions-portal.html).
+using the [Webin Portal](../general-guide/submissions-portal).
 
 ## Step 3: Submit the XMLs
 
@@ -185,8 +185,8 @@ After running the command above a receipt XML is returned. It will look like the
 
 ### Submit the XMLs Using Webin Portal
 
-XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal.html).
-Please refer to the [Webin Portal](../general-guide/submissions-portal.html) document for an example how
+XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal).
+Please refer to the [Webin Portal](../general-guide/submissions-portal) document for an example how
 to submit a study using XML. Other types of XMLs can be submitted using the same approach.
 
 ### The Receipt XML
@@ -219,5 +219,5 @@ but this time using the production service. Simply change the part in the URL fr
 curl -u username:password -F "SUBMISSION=@submission.xml" -F "ANALYSIS=@analysis.xml" "https://www.ebi.ac.uk/ena/submit/drop-box/submit/"
 ```
 
-Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal.html) change the URL from
+Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal) change the URL from
 `wwwdev.ebi.ac.uk` to `www.ebi.ac.uk`.

--- a/submit/general-guide/webin-cli.md
+++ b/submit/general-guide/webin-cli.md
@@ -128,8 +128,8 @@ made with Webin-CLI using the following tool:
 
 Each submission must be associated with a pre-registered study and a sample.
 
-- [Register a Study](../study.html)
-- [Register a Sample](../samples.html)
+- [Register a Study](../study)
+- [Register a Sample](../samples)
 
 
 ### Stage 2: Prepare the Files
@@ -247,13 +247,13 @@ Sequence based submission support the following formats:
 - FASTA: Sequences in fasta format
 - FLATFILE: Sequences in EMBL-Bank flat file format
 
-The following additional formats are supported for [genome assembly submissions](../assembly.html):
+The following additional formats are supported for [genome assembly submissions](../assembly):
 
 - AGP: Sequences in [AGP format](https://www.ncbi.nlm.nih.gov/assembly/agp/AGP_Specification/)
 - CHROMOSOME_LIST: list of chromosomes
 - UNLOCALISED_LIST: list of unlocalised sequences
 
-The following formats are supported for [read submissions](../reads/webin-cli.html):
+The following formats are supported for [read submissions](../reads/webin-cli):
 
 - BAM: BAM file
 - CRAM: CRAM file

--- a/submit/reads/webin-cli.md
+++ b/submit/reads/webin-cli.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 Sequence read data can be submitted to the European Nucleotide Archive (ENA) 
-using the [Webin command line submission interface](../general-guide/webin-cli.html) with `-context reads` option. 
+using the [Webin command line submission interface](../general-guide/webin-cli) with `-context reads` option. 
  
 A sequence read submission consists of:
 - General experiment information

--- a/submit/samples/programmatic.md
+++ b/submit/samples/programmatic.md
@@ -185,7 +185,7 @@ The submission XML declares one or more Webin submission service actions.
 In this case the action is `<ADD/>` which is used to submit new objects.
 
 The XMLs can be submitted programmatically, using CURL on command line or
-using the [Webin Portal](../general-guide/submissions-portal.html).
+using the [Webin Portal](../general-guide/submissions-portal).
 
 ## Submit the XMLs using CURL
 
@@ -217,8 +217,8 @@ After running the command above a receipt XML is returned. It will look like the
 
 ## Submit the XMLs using Webin Portal
 
-XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal.html).
-Please refer to the [Webin Portal](../general-guide/submissions-portal.html) document for an example how
+XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal).
+Please refer to the [Webin Portal](../general-guide/submissions-portal) document for an example how
 to submit a study using XML. Other types of XMLs can be submitted using the same approach.
 
 ## The Receipt XML
@@ -270,5 +270,5 @@ but this time using the production service. Simply change the part in the URL fr
 curl -u username:password -F "SUBMISSION=@submission.xml" -F "SAMPLE=@sample.xml" "https://www.ebi.ac.uk/ena/submit/drop-box/submit/"
 ```
 
-Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal.html) change the URL from
+Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal) change the URL from
 `wwwdev.ebi.ac.uk` to `www.ebi.ac.uk`.

--- a/submit/samples/programmatic.md
+++ b/submit/samples/programmatic.md
@@ -138,7 +138,7 @@ The scientific name and common name are optional and will automatically be fille
 
 Taxon IDs are drawn from the NCBI Taxonomy database.
 If you aren't sure which taxon you need to use, or aren't sure of its taxon ID, you can learn how to find this out in
-the [Tips for Sample Taxonomy](../../faq/taxonomy.html) FAQ page.
+the [Tips for Sample Taxonomy](../../faq/taxonomy) FAQ page.
 
 In the above example, the sample source is environmental (`stomach metagenome`) and represents an unknown variety and quantity of organisms.
 Note that metagenomes use specific environmental terms.

--- a/submit/study/programmatic.md
+++ b/submit/study/programmatic.md
@@ -110,8 +110,8 @@ After running the command above a receipt XML is returned. It will look like the
 
 ## Submit the XMLs using Webin Portal
 
-XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal.html).
-Please refer to the [Webin Portal](../general-guide/submissions-portal.html) document for an example how
+XMLs can also be submitted interactively using the [Webin Portal](../general-guide/submissions-portal).
+Please refer to the [Webin Portal](../general-guide/submissions-portal) document for an example how
 to submit a study using XML. Other types of XMLs can be submitted using the same approach. 
 
 ## The Receipt XML
@@ -156,5 +156,6 @@ but this time using the production service. Simply change the part in the URL fr
 curl -u username:password -F "SUBMISSION=@submission.xml" -F "PROJECT=@project.xml" "https://www.ebi.ac.uk/ena/submit/drop-box/submit/"
 ```
 
-Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal.html) change the URL from 
+Similarly, if you are using the [Webin Portal](../general-guide/submissions-portal) change the URL from 
 `wwwdev.ebi.ac.uk` to `www.ebi.ac.uk`.
+


### PR DESCRIPTION
- dependencies specified in requirements.txt up to newer versions than the default for older projects (https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx)
- '.html' removed from end of links in .md files
- recommonmark parser is deprecated - see details at https://recommonmark.readthedocs.io/en/latest/index.html