### PR TITLE
chore: configure codespell

### DIFF
--- a/.codespell_ignore_words.txt
+++ b/.codespell_ignore_words.txt
@@ -1,0 +1,5 @@
+claus
+alpha-numeric
+wya
+otu
+structed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words = .codespell_ignore_words.txt


### PR DESCRIPTION
With this configuration, codespell does not show false positives at the moment

I used this configuration to fix typos, see PR https://github.com/enasequence/read_docs/pull/159