### PR TITLE
Address easy to fix sphinx warnings/errors

### DIFF
--- a/faq/archive-generated-analysis-files.rst
+++ b/faq/archive-generated-analysis-files.rst
@@ -1,6 +1,6 @@
-=============================
+================================
 Archive Generated Analysis Files
-=============================
+================================
 
 Archive generated analysis files are generated for primary and binned metagenome assemblies. These submissions
 will not have a GCA (assembly accession) or sequence accessions but only ERZ accessions.

--- a/faq/archive-generated-files.rst
+++ b/faq/archive-generated-files.rst
@@ -1,6 +1,6 @@
-=============================
+===========================
 Archive Generated Run Files
-=============================
+===========================
 
 Whenever possible, ENA provides access to two types of file for each run we
 present: the submitted file(s) and archive-generated file(s). Both are visible

--- a/faq/pathogen-subs-guide.rst
+++ b/faq/pathogen-subs-guide.rst
@@ -1,5 +1,5 @@
 General Pathogens Submissions Guide
-==================================
+===================================
 
 .. image:: images/pathogens_logo_1.png
  :width: 400

--- a/faq/runs.rst
+++ b/faq/runs.rst
@@ -260,7 +260,7 @@ To do this:
 7. Remove the 'checksum' value for the errored file(s) and enter the correct value. The checksum is shown in the pink
    box:
 
-.. images:: images/run_errors_md5_edit.png
+.. image:: images/run_errors_md5_edit.png
 
 8. When editing the checksum value, change only the 32-digit string: do not remove the quotation marks, the word
    'checksum', or any other parts of the XML

--- a/submit/general-guide/interactive.rst
+++ b/submit/general-guide/interactive.rst
@@ -28,7 +28,7 @@ service.
 
 
 What Can Be Submitted Through Webin Portal?
-==================================
+===========================================
 
 
 Some submissions can be done entirely through Webin Portal, for example you could submit a study comprising only read data

--- a/submit/general-guide/programmatic-v2.rst
+++ b/submit/general-guide/programmatic-v2.rst
@@ -164,9 +164,9 @@ For example, a submission with one sample object could be submitted like this:
     ]
     }
 
-===========
+============
 Receipt JSON
-===========
+============
 
 The ``success`` attribute in the receipt is ``true`` if the submission was successful and ``false`` if the submission was not successful.
 

--- a/update/metadata/interactive.rst
+++ b/update/metadata/interactive.rst
@@ -1,6 +1,6 @@
-=============================================================
+=======================================================================
 Updating Studies, Samples, Experiments, Runs and Analyses Interactively
-=============================================================
+=======================================================================
 
 
 The `Webin Portal <https://www.ebi.ac.uk/ena/submit/webin/>`_ allows you to edit some of your
@@ -128,7 +128,7 @@ If the submitted file has failed validation, it must be replaced with an identic
 
 
 Analysis Edits
-============
+==============
 
 
 1. Log in to `Webin Portal <https://www.ebi.ac.uk/ena/submit/webin/login>`_ and select the 'Analyses Report' button to be


### PR DESCRIPTION
- chore(rst): fix "title under/overline too short" warnings
- fix: rst tag is image not images, hence show image again
