### PR TITLE
Update annotation.rst

### DIFF
--- a/submit/annotation.rst
+++ b/submit/annotation.rst
@@ -1,22 +1,22 @@
 =========================
-How to Submit Annotations
+How to Submit Curations
 =========================
 
 Introduction
 ============
-Annotation has many valid and useful meanings in the realms of the nucleic sequences.
-The below annotation is currently about the metadata, particularly sample level metadata.
+'Curation' has many valid and useful meanings in the realms of the nucleic sequences.
+The below curation is about the metadata, particularly sample level metadata.
 
 Third Party Annotation
 ----------------------
-The ELIXIR Clearinghouse enables extension, correction and improvement of publicly available annotations on sample, sequence, run/experiment and study records available in the European Nucleotide Archive (ENA) (and by extension, as the wider International Nucleotide Sequence Database Collaboration (INSDC) databases). The overall aim is to make metadata more FAIR and improve its quality.
+The ELIXIR Clearinghouse enables extension, correction and improvement of publicly available curations on sample, sequence, run/experiment and study records available in the European Nucleotide Archive (ENA) (and by extension, as the wider International Nucleotide Sequence Database Collaboration (INSDC) databases). The overall aim is to make metadata more FAIR and improve its quality.
 
 Curations submitted to Clearinghouse will present alongside the record, **without the original archived metadata being changed**. This allows the scientific community to enhance existing metadata records, for example to add information gleaned from paper supplements, or propose improved attributes that previously did not conform to standards/ontologies, without modifying the original record (often) submitted by a different user.
 
 Important Notes
 ===============
 
-- At the time of writing third party annotation such as those from the Clearinghouse only appear in the ENA browser and not the equivalents of other INSDC members. This may change in the future.
+- At the time of writing third party curation such as those from the Clearinghouse only appear in the ENA browser and not the equivalents of other INSDC members. This may change in the future.
 
 
 For Examples and More Detail


### PR DESCRIPTION
Hi Peter, 
I changed all instances of the term 'annotation' to 'curation', to keep consistent with changes to third party curation indexing in advanced search.  See https://www.ebi.ac.uk/panda/jira/browse/DCP-3652 for more information.